### PR TITLE
Dda remove info text

### DIFF
--- a/sass/_customizations.scss
+++ b/sass/_customizations.scss
@@ -151,7 +151,7 @@ footer a {
 }
 .services-header h3 .fa {
   position: absolute;
-  top: 5px;
+  top: 1px;
   left: 3px;
   font-size: 24px;
   color: $modularstorage-color-d;
@@ -276,9 +276,9 @@ h2.sub-heading.heading-services {
   }
 
   input[type='checkbox'] {
-    margin-top: 3px;
+    float: left;
+    margin: 3px 4px 0;
   }
-
   .control-indicator {
     font-family: 'FontAwesome';
     text-decoration: none;

--- a/sass/_customizations.scss
+++ b/sass/_customizations.scss
@@ -91,7 +91,9 @@ footer a {
     padding: 0;
   }
 }
-
+#pagechartheader {
+  font-size: larger;
+}
 .interior-content p,
 .interior-content ul,
 .interior-content ol,


### PR DESCRIPTION
This PR removes the help text from the table category descriptions and changes text for the questions info button (i). The latter can be found in each question's Description [here for the list of questions](http://localhost/admin/structure/taxonomy/manage/facets/overview).

Also, I've tweaked the arrow next to "Select services..." and aligned the checkboxes in each question with the accompanying label text.

The Page Chart header is now the same font size as the "Select services..." header.

The text for Tier 1 storage was out of order and didn't have parens around _Tier 1_. It does now and that fixes the ordering problem as the blocks are in alphabetical order.