### PR TITLE
Remove popup dialog

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -174,7 +174,7 @@
             $(".facet").on("change", function (thefacet) {
                 var a = find_facet($(this).attr("facetid"));
 
-                $('.jump-to-chart').hide();
+                // $('.jump-to-chart').hide();
 
                 a.selected = ! a.selected;
                 if (! a.selected) {
@@ -428,15 +428,15 @@
       $('html, body').animate({
         scrollTop: $(".comparisonchart-wrapper-wrapper").offset().top
       }, 500);
-      $(".jump-to-chart").hide();
+    //   $(".jump-to-chart").hide();
     });
 
     $( "#modularstorage-services" ).on('click', '.cardcheckbox', function() {
-        $('.jump-to-chart').show();
+        // $('.jump-to-chart').show();
         var service_count = $('.cardcheckbox:checked').length;
         if (service_count < 1) {
               $('#container34').hide();
-            $(".jump-to-chart").hide();
+            // $(".jump-to-chart").hide();
         } else {
             $('#container34').show();
         }
@@ -455,7 +455,7 @@
     $('.btn-select-all').click(function(){
         $('.cardcheckbox').not('.mismatch .cardcheckbox').prop('checked', true);
         evaluate_services();
-        $('.jump-to-chart').show();
+        // $('.jump-to-chart').show();
         $('#container34').show();
         listenForScrollEvent($('#comparisonchart tbody'));
     });
@@ -463,7 +463,7 @@
     $('.btn-select-none').click(function(){
         $('.cardcheckbox').prop('checked', false);
         evaluate_services();
-        $('.jump-to-chart').hide();
+        // $('.jump-to-chart').hide();
         $('#container34').hide();  // not sure we want this
     });
 

--- a/sass/_customizations.scss
+++ b/sass/_customizations.scss
@@ -115,6 +115,10 @@ footer a {
 
 .cwd-scrolling-table .floating-row-header {
   background-color: lighten($medium-gray, 50);
+  & > div {
+    display: flex;
+    align-items: center;
+  }
 }
 
 .hero,
@@ -172,8 +176,11 @@ footer a {
 .services-header .btn-secondary {
   margin: 4px 0;
 }
-.step-1 + button {
-  margin-top: 1.75em;
+.step-1 {
+  font-size: larger;
+  & + button {
+    margin-top: 1.75em;
+  }
 }
 
 .title {

--- a/templates/finder.html.twig
+++ b/templates/finder.html.twig
@@ -68,7 +68,7 @@
         </div>
     </div>
 
-    <div class="jump-to-chart">
+    {# <div class="jump-to-chart">
         <div class="container">
             <div class="media">
                 <div class="media-body">
@@ -81,7 +81,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    </div> #}
     <div style="margin-top:25px;">
                   <p class="cert"><span class="fa fa-comments"></span>If you experience any issues with the tool,
 please email rchelp@rc.fas.harvard.edu</p>


### PR DESCRIPTION
this 
This pull request includes changes to deprecate the "jump-to-chart" feature and introduce minor styling updates to improve the UI. The most important changes involve commenting out or removing functionality related to "jump-to-chart" in both JavaScript and HTML files, as well as adding new styles and adjustments in the SCSS file for better visual alignment.

### Deprecation of "jump-to-chart" feature:
* [`js/app.js`](diffhunk://#diff-32cdce28ac549728f6a28999f6d874aa4f29e6da1406c28c3134cd8d421a866aL177-R177): Commented out all instances of `$('.jump-to-chart').hide()` and `$('.jump-to-chart').show()` to disable the feature without fully removing it. [[1]](diffhunk://#diff-32cdce28ac549728f6a28999f6d874aa4f29e6da1406c28c3134cd8d421a866aL177-R177) [[2]](diffhunk://#diff-32cdce28ac549728f6a28999f6d874aa4f29e6da1406c28c3134cd8d421a866aL431-R439) [[3]](diffhunk://#diff-32cdce28ac549728f6a28999f6d874aa4f29e6da1406c28c3134cd8d421a866aL458-R466)
* [`templates/finder.html.twig`](diffhunk://#diff-76666e187a1cf5c115c06922d8c6facc271f85b2bfaeab0f4207c574d13eb4e8L71-R71): Commented out the HTML structure for the "jump-to-chart" section, effectively removing it from the rendered page. [[1]](diffhunk://#diff-76666e187a1cf5c115c06922d8c6facc271f85b2bfaeab0f4207c574d13eb4e8L71-R71) [[2]](diffhunk://#diff-76666e187a1cf5c115c06922d8c6facc271f85b2bfaeab0f4207c574d13eb4e8L84-R84)

### UI styling updates:
* `sass/_customizations.scss`: 
  - Added `display: flex` and `align-items: center` to `.cwd-scrolling-table .floating-row-header > div` for better alignment of header content.
  - Updated `.step-1` to increase font size and adjusted the margin of adjacent buttons for improved spacing.